### PR TITLE
Update Bitboin index from 1 to 0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ resolver.addr('moneyonchain.rsk').then(console.log) // gets rsk address
 // 0x135601C736ddB4C58a4b8fd3CD9F66dF244d28AA
 
 
-resolver.addr('multichain.testing.rsk', 1).then(console.log) // gets btc address
+resolver.addr('multichain.testing.rsk', 0).then(console.log) // gets btc address
 // 1Ftu4C8VW18RkB8PZxXwwHocMLyEynLcrG
 ```
 


### PR DESCRIPTION
On the readme file, update Bitcoin's index from 0 to 1. This is what the [RNS Manager](https://github.com/rnsdomains/rns-manager-react/blob/develop/src/app/tabs/newAdmin/addresses/networks.json#L20) is using and is described in [slip-0044](https://github.com/satoshilabs/slips/blob/master/slip-0044.md).
